### PR TITLE
DIG: Set up Google Analytics and Add Tracking to the Landing Page #64

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,6 +27,20 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        {/* Google tag (gtag.js) */}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-NF9SF0PSM9"></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-NF9SF0PSM9');
+            `,
+          }}
+        />
+      </head>
       <body className="flex flex-col items-center justify-center min-h-screen bg-[#1a1a1a] text-[#00ff00] font-mono">
         <AuthProvider>
           {children}


### PR DESCRIPTION
- Add Google Analytics gtag.js script to the head section
- Configure tracking for all pages via root layout
- Use dangerouslySetInnerHTML for proper script execution in Next.js