### PR TITLE
feat: automation API endpoints for transcript pipeline (#148)

### DIFF
--- a/app/api/automation/transcripts/[id]/route.ts
+++ b/app/api/automation/transcripts/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { createServerClient, isServerSupabaseConfigured } from '@/lib/supabase';
+import { validateAutomationApiKey } from '@/lib/automation-auth';
+import { transcriptUpdateSchema } from '@/types/transcripts';
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authError = validateAutomationApiKey(request);
+  if (authError) return authError;
+
+  if (!isServerSupabaseConfigured()) {
+    return NextResponse.json({ error: 'Supabase is not configured' }, { status: 500 });
+  }
+
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = transcriptUpdateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const updateData: Record<string, unknown> = {};
+  if (parsed.data.title !== undefined) updateData.title = parsed.data.title;
+  if (parsed.data.transcript_text !== undefined) updateData.transcript_text = parsed.data.transcript_text;
+  if (parsed.data.is_processed !== undefined) updateData.is_processed = parsed.data.is_processed;
+
+  if (Object.keys(updateData).length === 0) {
+    return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+  }
+
+  try {
+    const supabase = createServerClient();
+    const { data, error } = await supabase
+      .from('transcripts')
+      .update(updateData)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    if (!data) {
+      return NextResponse.json({ error: 'Transcript not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ transcript: data });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/automation/transcripts/next-unprocessed/route.ts
+++ b/app/api/automation/transcripts/next-unprocessed/route.ts
@@ -3,33 +3,15 @@ import { createServerClient, isServerSupabaseConfigured } from '@/lib/supabase';
 import { validateAutomationApiKey } from '@/lib/automation-auth';
 
 export async function GET(request: Request) {
-  // #region agent log
-  fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'next-unprocessed/route.ts:GET',message:'handler entry',data:{},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H2-H5'})}).catch(()=>{});
-  // #endregion
   const authError = validateAutomationApiKey(request);
-  if (authError) {
-    // #region agent log
-    fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'next-unprocessed/route.ts:authReturn',message:'returning authError',data:{status:authError.status},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H1'})}).catch(()=>{});
-    // #endregion
-    return authError;
-  }
+  if (authError) return authError;
 
-  const supabaseConfigured = isServerSupabaseConfigured();
-  // #region agent log
-  fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'next-unprocessed/route.ts:supabaseCheck',message:'after isServerSupabaseConfigured',data:{supabaseConfigured},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H2'})}).catch(()=>{});
-  // #endregion
-  if (!supabaseConfigured) {
-    return NextResponse.json(
-      { error: 'Supabase is not configured' },
-      { status: 500 }
-    );
+  if (!isServerSupabaseConfigured()) {
+    return NextResponse.json({ error: 'Supabase is not configured' }, { status: 500 });
   }
 
   try {
     const supabase = createServerClient();
-    // #region agent log
-    fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'next-unprocessed/route.ts:beforeQuery',message:'before supabase query',data:{},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H3-H4'})}).catch(()=>{});
-    // #endregion
     const { data, error } = await supabase
       .from('transcripts')
       .select('*')
@@ -38,23 +20,13 @@ export async function GET(request: Request) {
       .limit(1)
       .maybeSingle();
 
-    // #region agent log
-    fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'next-unprocessed/route.ts:afterQuery',message:'after supabase query',data:{hasData:!!data,errorMessage:error?.message ?? null},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H3'})}).catch(()=>{});
-    // #endregion
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    if (!data) {
-      return NextResponse.json({ transcript: null }, { status: 200 });
-    }
-
-    return NextResponse.json({ transcript: data }, { status: 200 });
+    return NextResponse.json({ transcript: data ?? null });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
-    // #region agent log
-    fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'next-unprocessed/route.ts:catch',message:'caught exception',data:{message},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H4-H5'})}).catch(()=>{});
-    // #endregion
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/automation/transcripts/route.ts
+++ b/app/api/automation/transcripts/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { createServerClient, isServerSupabaseConfigured } from '@/lib/supabase';
+import { validateAutomationApiKey } from '@/lib/automation-auth';
+import { transcriptCreateSchema } from '@/types/transcripts';
+
+export async function POST(request: Request) {
+  const authError = validateAutomationApiKey(request);
+  if (authError) return authError;
+
+  if (!isServerSupabaseConfigured()) {
+    return NextResponse.json({ error: 'Supabase is not configured' }, { status: 500 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = transcriptCreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  const rawTitle = parsed.data.title?.trim();
+  const title =
+    rawTitle && rawTitle.length > 0
+      ? rawTitle
+      : 'NEW_' + new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+
+  try {
+    const supabase = createServerClient();
+    const { data, error } = await supabase
+      .from('transcripts')
+      .insert({
+        title,
+        transcript_text: parsed.data.transcript_text,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ transcript: data }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/lib/automation-auth.ts
+++ b/lib/automation-auth.ts
@@ -5,20 +5,11 @@ const ENV_KEY = 'CYBERWORLD_AUTOMATION_API_KEY';
 /**
  * Validates the request using the automation API key.
  * Accepts X-API-Key header or Authorization: Bearer <key>.
- * Returns null if valid; returns a NextResponse (401) if invalid or missing key.
+ * Returns null if valid; returns a NextResponse (401/500) if invalid or missing key.
  */
 export function validateAutomationApiKey(request: Request): NextResponse | null {
-  // #region agent log
-  const hasXApiKey = !!request.headers.get('x-api-key');
-  const authHeader = request.headers.get('authorization');
-  const hasBearer = !!(authHeader?.startsWith('Bearer '));
-  fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'automation-auth.ts:validateAutomationApiKey',message:'auth check entry',data:{hasXApiKey,hasBearer},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H1'})}).catch(()=>{});
-  // #endregion
   const expected = process.env[ENV_KEY];
   if (!expected || expected.trim() === '') {
-    // #region agent log
-    fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'automation-auth.ts:envMissing',message:'returning 500 env key not configured',data:{},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H1'})}).catch(()=>{});
-    // #endregion
     return NextResponse.json(
       {
         error: 'Automation API key is not configured on the server. Set CYBERWORLD_AUTOMATION_API_KEY in .env.local (or your environment) and restart the app.',
@@ -28,22 +19,17 @@ export function validateAutomationApiKey(request: Request): NextResponse | null 
   }
 
   const apiKeyHeader = request.headers.get('x-api-key');
+  const authHeader = request.headers.get('authorization');
   const token =
     apiKeyHeader ??
     (authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : null);
 
   if (!token || token !== expected) {
-    // #region agent log
-    fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'automation-auth.ts:unauthorized',message:'returning 401 invalid or missing key',data:{},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H1'})}).catch(()=>{});
-    // #endregion
     return NextResponse.json(
       { error: 'Unauthorized: invalid or missing API key' },
       { status: 401 }
     );
   }
 
-  // #region agent log
-  fetch('http://127.0.0.1:7245/ingest/09142726-0b46-49c0-b91d-40a2cb60bfcb',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'automation-auth.ts:valid',message:'auth passed',data:{},timestamp:Date.now(),sessionId:'debug-session',hypothesisId:'H1'})}).catch(()=>{});
-  // #endregion
   return null;
 }


### PR DESCRIPTION
## Summary
- **`POST /api/automation/transcripts`** — Create transcripts via API key auth (no browser session needed)
- **`PATCH /api/automation/transcripts/[id]`** — Update title, text, or mark as processed
- **Cleaned up debug agent logs** — Removed `#region agent log` fetch calls from `automation-auth.ts` and `next-unprocessed/route.ts`

## API Details

### POST /api/automation/transcripts
```
X-API-Key: <CYBERWORLD_AUTOMATION_API_KEY>
Content-Type: application/json

{ "title": "optional", "transcript_text": "required" }
→ 201 { transcript: {...} }
```

### PATCH /api/automation/transcripts/:id
```
X-API-Key: <CYBERWORLD_AUTOMATION_API_KEY>
Content-Type: application/json

{ "title": "optional", "transcript_text": "optional", "is_processed": true }
→ 200 { transcript: {...} }
```

## Architecture
```
GusClaw heartbeat (every 30 min)
  → GET /api/automation/transcripts/next-unprocessed
  → if transcript found:
      → run editor pipeline
      → generate TSX blog post
      → create PR to legend repo
      → PATCH /api/automation/transcripts/:id  { is_processed: true, title: "..." }
```

Closes #148

## Test plan
- [x] `npm run build` passes with all 3 automation routes registered
- [ ] Test POST with `curl -X POST -H "X-API-Key: ..." -H "Content-Type: application/json" -d '{"transcript_text":"test"}' /api/automation/transcripts`
- [ ] Test PATCH with `curl -X PATCH -H "X-API-Key: ..." -H "Content-Type: application/json" -d '{"is_processed":true}' /api/automation/transcripts/<id>`
- [ ] Verify `CYBERWORLD_AUTOMATION_API_KEY` is set in Vercel production env

🤖 Generated with [Claude Code](https://claude.com/claude-code)