### PR TITLE
perf: reduce TBT by deferring non-critical JS (#147)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,10 @@
 import type { Metadata } from 'next';
 import Script from 'next/script';
 import '../app/globals.css';
-import PerformanceMonitor from '@/components/PerformanceMonitor';
 import AuthorSchema from '@/components/AuthorSchema';
-import GoogleAnalytics from '@/components/GoogleAnalytics';
 import AnalyticsClient from '@/components/AnalyticsClient';
 import FAQSchema from '@/components/FAQSchema';
-import ChatWidget from '@/components/ChatWidget';
-import DebugErrorReporter from '@/components/DebugErrorReporter';
+import DeferredWidgets from '@/components/DeferredWidgets';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://cyberworldbuilders.com'),
@@ -89,8 +86,6 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        {/* Font preloads removed - fonts not available */}
-        
         {/* WebSite Schema with Search Action */}
         <script
           type="application/ld+json"
@@ -232,14 +227,11 @@ export default function RootLayout({
         />
       </head>
       <body className="flex flex-col items-center justify-center min-h-screen bg-[#1a1a1a] text-[#00ff00] font-mono">
-        <DebugErrorReporter />
         {children}
         <AnalyticsClient />
-        <GoogleAnalytics />
-        <PerformanceMonitor />
         <AuthorSchema />
         <FAQSchema />
-        <ChatWidget />
+        <DeferredWidgets />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,9 @@ import ProofSection from '../components/ProofSection';
 import AboutSection from '../components/AboutSection';
 import ContactCTA from '../components/ContactCTA';
 import SocialLinks from '../components/SocialLinks';
-import ScrollTracker from '../components/ScrollTracker';
+import dynamic from 'next/dynamic';
+
+const ScrollTracker = dynamic(() => import('../components/ScrollTracker'), { ssr: false });
 
 const TRACKED_SECTIONS = ['hero', 'services', 'proof', 'about', 'contact', 'faq'];
 

--- a/components/DeferredWidgets.tsx
+++ b/components/DeferredWidgets.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const GoogleAnalytics = dynamic(() => import('@/components/GoogleAnalytics'), { ssr: false });
+const PerformanceMonitor = dynamic(() => import('@/components/PerformanceMonitor'), { ssr: false });
+const ChatWidget = dynamic(() => import('@/components/ChatWidget'), { ssr: false });
+
+export default function DeferredWidgets() {
+  return (
+    <>
+      <GoogleAnalytics />
+      <PerformanceMonitor />
+      <ChatWidget />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- **Removed `DebugErrorReporter`** — was fetching `localhost:7245` in production on every error (network hang + wasted bytes)
- **Lazy-loaded ChatWidget, GoogleAnalytics, PerformanceMonitor** — bundled into `DeferredWidgets` client component with `dynamic(ssr: false)` so they load after first paint
- **Lazy-loaded ScrollTracker** on homepage — was firing IntersectionObserver + scroll listeners + network tracking calls during initial render

## Why
Today's SEO report (#147) flagged TBT at 1,037ms (Poor threshold: >600ms). These components were all executing JavaScript on the main thread during initial render but aren't needed for first paint. Deferring them should significantly reduce blocking time.

## What's deferred vs. what renders immediately
| Component | Before | After |
|-----------|--------|-------|
| DebugErrorReporter | Renders in layout | **Removed** (localhost debug tool) |
| ChatWidget | Renders in layout (blocking) | Lazy-loaded after paint |
| GoogleAnalytics | Renders in layout (blocking) | Lazy-loaded after paint |
| PerformanceMonitor | Renders in layout (blocking) | Lazy-loaded after paint |
| ScrollTracker | Renders on homepage (blocking) | Lazy-loaded after paint |

Ref #147

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:ci` passes (25/25)
- [ ] Verify Vercel preview: ChatWidget appears, analytics fires
- [ ] Run Lighthouse on preview to measure TBT improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)