### PR TITLE
feat: restore static tag pages, add blog & tag search (#157)

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -207,7 +207,7 @@ export default async function BlogPost({ params }: BlogPostProps) {
                 {(metadata.tags || metadata.keywords || []).map((tag: string) => (
                   <Link
                     key={tag}
-                    href={`/blog?tag=${encodeURIComponent(tag)}`}
+                    href={`/blog/tag/${encodeURIComponent(tag)}`}
                     className="px-3 py-1 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-full text-sm text-[#00ff00]/80 hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors cursor-pointer"
                     title={`Filter by ${tag}`}
                   >

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -5,6 +5,7 @@ import Breadcrumb from '@/components/Breadcrumb';
 import SimpleSocialShare from '@/components/SimpleSocialShare';
 import TopicClusters from '@/components/TopicClusters';
 import PageBackground from '@/components/PageBackground';
+import BlogPostList from '@/components/BlogPostList';
 import { getAllPostsWithMetadata } from '@/lib/post-metadata';
 import type { Metadata } from 'next';
 
@@ -177,44 +178,17 @@ export default async function BlogIndex({ searchParams }: BlogIndexProps) {
         />
       </div>
       
-      <div className="w-full max-w-2xl">
-        {posts.map((post) => (
-          <div key={post.slug} className="mb-6">
-            <Link
-              href={`/blog/${post.slug}`}
-              className="text-2xl text-[#00ff00] hover:text-[#00cc00] hover:underline"
-            >
-              {post.title}
-            </Link>
-          </div>
-        ))}
-      </div>
-      
+      <BlogPostList
+        posts={posts.map((p) => ({ slug: p.slug, title: p.title, mtime: p.mtime.toISOString() }))}
+        totalPages={totalPages}
+        currentPage={currentPage}
+        paginationBase={paginationBase}
+      />
+
       {/* Topic Clusters */}
       <div className="w-full max-w-4xl">
         <TopicClusters allPosts={allPosts} />
       </div>
-      
-      {totalPages > 1 && (
-        <div className="flex gap-4 mt-8">
-          {currentPage > 1 && (
-            <Link
-              href={`${paginationBase}${paginationBase.includes('?') ? '&' : '?'}page=${currentPage - 1}`}
-              className="text-[#00ff00] hover:text-[#00cc00] hover:underline"
-            >
-              ← Previous
-            </Link>
-          )}
-          {currentPage < totalPages && (
-            <Link
-              href={`${paginationBase}${paginationBase.includes('?') ? '&' : '?'}page=${currentPage + 1}`}
-              className="text-[#00ff00] hover:text-[#00cc00] hover:underline"
-            >
-              Next →
-            </Link>
-          )}
-        </div>
-      )}
       </div>
     </div>
   );

--- a/app/blog/tag/[tag]/page.tsx
+++ b/app/blog/tag/[tag]/page.tsx
@@ -1,0 +1,148 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import Breadcrumb from '@/components/Breadcrumb';
+import PageBackground from '@/components/PageBackground';
+import { getAllPosts } from '@/lib/post-metadata';
+import type { PostIndexEntry } from '@/lib/post-metadata';
+import type { Metadata } from 'next';
+
+export const revalidate = 3600;
+
+interface TagPageProps {
+  params: Promise<{ tag: string }>;
+}
+
+function getPostsForTag(tag: string): PostIndexEntry[] {
+  const decoded = decodeURIComponent(tag);
+  return getAllPosts().filter(
+    (p) => p.tags.includes(decoded) || p.keywords.includes(decoded)
+  );
+}
+
+function getAllUniqueTags(): string[] {
+  const tags = new Set<string>();
+  for (const post of getAllPosts()) {
+    for (const t of post.tags) tags.add(t);
+    for (const k of post.keywords) tags.add(k);
+  }
+  return Array.from(tags);
+}
+
+export async function generateStaticParams() {
+  return getAllUniqueTags().map((tag) => ({ tag: encodeURIComponent(tag) }));
+}
+
+export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
+  const { tag } = await params;
+  const decoded = decodeURIComponent(tag);
+  const posts = getPostsForTag(tag);
+  const title = `Posts tagged "${decoded}" — CyberWorld Builders Blog`;
+  const description = `Browse ${posts.length} blog post${posts.length === 1 ? '' : 's'} tagged with "${decoded}" — Software engineering insights from CyberWorld Builders.`;
+  const canonical = `https://cyberworldbuilders.com/blog/tag/${encodeURIComponent(decoded)}`;
+
+  return {
+    title,
+    description,
+    openGraph: { title, description, url: canonical, type: 'website' },
+    twitter: { card: 'summary_large_image', title, description },
+    alternates: { canonical },
+  };
+}
+
+export default async function TagPage({ params }: TagPageProps) {
+  const { tag } = await params;
+  const decoded = decodeURIComponent(tag);
+  const posts = getPostsForTag(tag);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center py-8 relative">
+      <PageBackground opacity={20} fullWidth={true} />
+
+      <div className="relative z-10 w-full flex flex-col items-center">
+        <div className="flex justify-center mb-4">
+          <Link href="/">
+            <Image
+              src="/icons/favicon.ico"
+              alt="CyberWorld Builders - Software Engineering & Consulting Services"
+              className="w-12 h-12 rounded-full"
+              width={48}
+              height={48}
+              loading="lazy"
+            />
+          </Link>
+        </div>
+
+        <div className="w-full max-w-2xl mb-6">
+          <Breadcrumb
+            items={[
+              { label: 'Home', href: '/' },
+              { label: 'Blog', href: '/blog' },
+              { label: 'Tags', href: '/blog/tags' },
+              { label: `#${decoded}` },
+            ]}
+          />
+        </div>
+
+        <h1 className="text-4xl font-bold mb-2 text-[#00ff00]">
+          #{decoded}
+        </h1>
+        <p className="text-[#00ff00]/70 mb-8">
+          {posts.length} post{posts.length === 1 ? '' : 's'}
+        </p>
+
+        <div className="w-full max-w-2xl">
+          {posts.length === 0 ? (
+            <p className="text-[#00ff00]/70 text-center">No posts found for this tag.</p>
+          ) : (
+            posts.map((post) => (
+              <div key={post.slug} className="mb-6 border-b border-[#00ff00]/10 pb-6">
+                <Link
+                  href={`/blog/${post.slug}`}
+                  className="text-2xl text-[#00ff00] hover:text-[#00cc00] hover:underline"
+                >
+                  {post.title}
+                </Link>
+                <p className="text-[#00ff00]/50 text-sm mt-1">
+                  {new Date(post.publishedDate).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </p>
+                {post.description && (
+                  <p className="text-[#00ff00]/70 mt-2 text-sm">{post.description}</p>
+                )}
+                <div className="flex flex-wrap gap-2 mt-3">
+                  {post.tags.slice(0, 5).map((t) => (
+                    <Link
+                      key={t}
+                      href={`/blog/tag/${encodeURIComponent(t)}`}
+                      className="px-2 py-0.5 bg-[#00ff00]/10 border border-[#00ff00]/20 rounded-full text-xs text-[#00ff00]/60 hover:text-[#00ff00] transition-colors"
+                    >
+                      #{t}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="mt-8 flex gap-4">
+          <Link
+            href="/blog/tags"
+            className="inline-flex items-center px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-lg text-[#00ff00] hover:bg-[#00ff00]/20 transition-colors"
+          >
+            All Tags
+          </Link>
+          <Link
+            href="/blog"
+            className="inline-flex items-center px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-lg text-[#00ff00] hover:bg-[#00ff00]/20 transition-colors"
+          >
+            All Posts
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/blog/tags/page.tsx
+++ b/app/blog/tags/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import Breadcrumb from '@/components/Breadcrumb';
 import PageBackground from '@/components/PageBackground';
+import TagGrid from '@/components/TagGrid';
 import { getAllPostsWithMetadata } from '@/lib/post-metadata';
 import type { Metadata } from 'next';
 
@@ -26,34 +27,29 @@ export const metadata: Metadata = {
 
 export default async function TagsPage() {
   try {
-    // Get all posts with metadata
     const allPosts = await getAllPostsWithMetadata();
-    
+
     // Collect all tags with their post counts
     const tagCounts = new Map<string, number>();
-    
+
     allPosts.forEach(post => {
-      // Count tags
       if (post.metadata.tags) {
         post.metadata.tags.forEach(tag => {
           tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
         });
       }
-      
-      // Count keywords as tags too
       if (post.metadata.keywords) {
         post.metadata.keywords.forEach(keyword => {
           tagCounts.set(keyword, (tagCounts.get(keyword) || 0) + 1);
         });
       }
     });
-    
-    // Convert to array and sort by count (most used first)
+
     const sortedTags = Array.from(tagCounts.entries())
       .sort((a, b) => b[1] - a[1]);
-    
-    // Group tags by category for better organization
-    const tagCategories: { [category: string]: string[] } = {
+
+    // Group tags by category
+    const tagCategories: Record<string, string[]> = {
       'Technology': ['AI', 'automation', 'technology', 'innovation', 'digital-tools', 'blog-bot', 'AI-agents', 'content-creation', 'digital-legacy'],
       'Career & Development': ['career-development', 'professional-validation', 'personal-branding', 'content-strategy', 'career', 'first-job', 'career-transition'],
       'Business & Marketing': ['marketing', 'business', 'startup', 'partnerships', 'founder', 'engineer', 'industry-trends'],
@@ -63,22 +59,18 @@ export default async function TagsPage() {
       'Healthcare & Industry': ['healthcare', 'EMR', 'electronic-medical-records', 'technology'],
       'Learning & Education': ['coding-journey', 'self-directed-learning', 'programming', 'HTML', 'CSS', 'Flash', 'biographical', 'early-career'],
       'Productivity & Frameworks': ['productivity', 'framework', 'value', 'passion', 'alignment', 'career-development'],
-      'Other': []
+      'Other': [],
     };
-    
-    // Categorize tags
-    const categorizedTags: { [category: string]: Array<[string, number]> } = {};
+
+    const categorizedTags: Record<string, Array<[string, number]>> = {};
     const uncategorizedTags: Array<[string, number]> = [];
-    
-    // Initialize categories
+
     Object.keys(tagCategories).forEach(category => {
       categorizedTags[category] = [];
     });
-    
-    // Categorize tags
+
     sortedTags.forEach(([tag, count]) => {
       let categorized = false;
-      
       for (const [category, categoryTags] of Object.entries(tagCategories)) {
         if (categoryTags.includes(tag)) {
           categorizedTags[category].push([tag, count]);
@@ -86,108 +78,65 @@ export default async function TagsPage() {
           break;
         }
       }
-      
       if (!categorized) {
         uncategorizedTags.push([tag, count]);
       }
     });
-    
-    // Add uncategorized tags to "Other"
+
     categorizedTags['Other'] = uncategorizedTags;
-    
+
     return (
       <div className="min-h-screen flex flex-col items-center py-8 relative">
-        {/* Page Background */}
         <PageBackground opacity={20} fullWidth={true} />
-        
-        {/* Content with higher z-index */}
+
         <div className="relative z-10 w-full flex flex-col items-center">
-        <div className="flex justify-center mb-4">
-          <Link href="/">
-            <Image
-              src="/icons/favicon.ico"
-              alt="CyberWorld Builders - Software Engineering & Consulting Services"
-              className="w-12 h-12 rounded-full"
-              width={48}
-              height={48}
-              loading="lazy"
-            />
-          </Link>
-        </div>
-        
-        {/* Breadcrumb Navigation */}
-        <div className="w-full max-w-4xl mb-6">
-          <Breadcrumb 
-            items={[
-              { label: 'Home', href: '/' },
-              { label: 'Blog', href: '/blog' },
-              { label: 'Tags' }
-            ]} 
-          />
-        </div>
-        
-        <div className="w-full max-w-4xl">
-          <div className="text-center mb-8">
-            <h1 className="text-4xl font-bold mb-4 text-[#00ff00]">
-              All Tags
-            </h1>
-            <p className="text-[#00ff00]/70 text-lg">
-              Browse posts by topic, technology, or interest area
-            </p>
-          </div>
-          
-          {/* Tags by Category */}
-          <div className="space-y-8">
-            {Object.entries(categorizedTags).map(([category, tags]) => {
-              if (tags.length === 0) return null;
-              
-              return (
-                <section key={category} className="border border-[#00ff00]/20 rounded-lg p-6">
-                  <h2 className="text-2xl font-bold mb-4 text-[#00ff00]">{category}</h2>
-                  <div className="flex flex-wrap gap-3">
-                    {tags.map(([tag, count]) => (
-                      <Link
-                        key={tag}
-                        href={`/blog?tag=${encodeURIComponent(tag)}`}
-                        className="group px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-full text-[#00ff00]/80 hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors"
-                      >
-                        <span className="font-medium">#{tag}</span>
-                        <span className="ml-2 text-xs text-[#00ff00]/60 group-hover:text-[#00ff00]/80">
-                          ({count})
-                        </span>
-                      </Link>
-                    ))}
-                  </div>
-                </section>
-              );
-            })}
-          </div>
-          
-          {/* Stats */}
-          <div className="mt-12 text-center">
-            <div className="inline-flex items-center gap-8 px-6 py-4 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-lg">
-              <div className="text-center">
-                <div className="text-2xl font-bold text-[#00ff00]">{sortedTags.length}</div>
-                <div className="text-sm text-[#00ff00]/70">Total Tags</div>
-              </div>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-[#00ff00]">{allPosts.length}</div>
-                <div className="text-sm text-[#00ff00]/70">Total Posts</div>
-              </div>
-            </div>
-          </div>
-          
-          {/* Back to Blog */}
-          <div className="mt-8 text-center">
-            <Link
-              href="/blog"
-              className="inline-flex items-center px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-lg text-[#00ff00] hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors"
-            >
-              ← Back to All Posts
+          <div className="flex justify-center mb-4">
+            <Link href="/">
+              <Image
+                src="/icons/favicon.ico"
+                alt="CyberWorld Builders - Software Engineering & Consulting Services"
+                className="w-12 h-12 rounded-full"
+                width={48}
+                height={48}
+                loading="lazy"
+              />
             </Link>
           </div>
+
+          <div className="w-full max-w-4xl mb-6">
+            <Breadcrumb
+              items={[
+                { label: 'Home', href: '/' },
+                { label: 'Blog', href: '/blog' },
+                { label: 'Tags' },
+              ]}
+            />
+          </div>
+
+          <div className="w-full max-w-4xl">
+            <div className="text-center mb-8">
+              <h1 className="text-4xl font-bold mb-4 text-[#00ff00]">All Tags</h1>
+              <p className="text-[#00ff00]/70 text-lg">
+                Browse posts by topic, technology, or interest area
+              </p>
+            </div>
+
+            <TagGrid
+              categorizedTags={categorizedTags}
+              totalTags={sortedTags.length}
+              totalPosts={allPosts.length}
+            />
+
+            <div className="mt-8 text-center">
+              <Link
+                href="/blog"
+                className="inline-flex items-center px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-lg text-[#00ff00] hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors"
+              >
+                &larr; Back to All Posts
+              </Link>
+            </div>
+          </div>
         </div>
-        </div> {/* Closing div for content wrapper */}
       </div>
     );
   } catch (error) {
@@ -201,7 +150,7 @@ export default async function TagsPage() {
             href="/blog"
             className="inline-flex items-center px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-lg text-[#00ff00] hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors"
           >
-            ← Back to Blog
+            &larr; Back to Blog
           </Link>
         </div>
       </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -28,6 +28,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Dynamic blog posts
   let blogPosts: MetadataRoute.Sitemap = []
+  let tagPages: MetadataRoute.Sitemap = []
 
   try {
     const posts = getAllPosts()
@@ -38,9 +39,23 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly' as const,
       priority: post.isFeatured ? 0.8 : 0.7,
     }))
+
+    // Collect unique tags
+    const tags = new Set<string>()
+    for (const post of posts) {
+      for (const t of post.tags) tags.add(t)
+      for (const k of post.keywords) tags.add(k)
+    }
+
+    tagPages = Array.from(tags).map(tag => ({
+      url: `${baseUrl}/blog/tag/${encodeURIComponent(tag)}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.5,
+    }))
   } catch (error) {
     console.error('Error reading blog posts for sitemap:', error)
   }
 
-  return [...staticPages, ...blogPosts]
+  return [...staticPages, ...blogPosts, ...tagPages]
 }

--- a/components/BlogPostList.tsx
+++ b/components/BlogPostList.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import SearchInput from './SearchInput';
+
+interface BlogPost {
+  slug: string;
+  title: string;
+  mtime: string; // ISO string for serialization
+}
+
+interface BlogPostListProps {
+  posts: BlogPost[];
+  totalPages: number;
+  currentPage: number;
+  paginationBase: string;
+}
+
+export default function BlogPostList({ posts, totalPages, currentPage, paginationBase }: BlogPostListProps) {
+  const [query, setQuery] = useState('');
+
+  const filtered = query
+    ? posts.filter((p) => p.title.toLowerCase().includes(query.toLowerCase()))
+    : posts;
+
+  return (
+    <>
+      <div className="w-full max-w-2xl mb-6 flex justify-center">
+        <SearchInput placeholder="Search posts by title..." onSearch={setQuery} />
+      </div>
+
+      <div className="w-full max-w-2xl">
+        {filtered.length === 0 ? (
+          <p className="text-[#00ff00]/70 text-center">No posts match your search.</p>
+        ) : (
+          filtered.map((post) => (
+            <div key={post.slug} className="mb-6">
+              <Link
+                href={`/blog/${post.slug}`}
+                className="text-2xl text-[#00ff00] hover:text-[#00cc00] hover:underline"
+              >
+                {post.title}
+              </Link>
+            </div>
+          ))
+        )}
+      </div>
+
+      {!query && totalPages > 1 && (
+        <div className="flex gap-4 mt-8">
+          {currentPage > 1 && (
+            <Link
+              href={`${paginationBase}${paginationBase.includes('?') ? '&' : '?'}page=${currentPage - 1}`}
+              className="text-[#00ff00] hover:text-[#00cc00] hover:underline"
+            >
+              &larr; Previous
+            </Link>
+          )}
+          {currentPage < totalPages && (
+            <Link
+              href={`${paginationBase}${paginationBase.includes('?') ? '&' : '?'}page=${currentPage + 1}`}
+              className="text-[#00ff00] hover:text-[#00cc00] hover:underline"
+            >
+              Next &rarr;
+            </Link>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/SearchInput.tsx
+++ b/components/SearchInput.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+
+interface SearchInputProps {
+  placeholder: string;
+  onSearch: (query: string) => void;
+}
+
+export default function SearchInput({ placeholder, onSearch }: SearchInputProps) {
+  const [value, setValue] = useState('');
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setValue(e.target.value);
+    onSearch(e.target.value);
+  }
+
+  function handleClear() {
+    setValue('');
+    onSearch('');
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Escape') handleClear();
+  }
+
+  return (
+    <div className="relative w-full max-w-md">
+      <input
+        type="text"
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        className="w-full px-4 py-2 bg-black/50 border border-[#00ff00]/30 rounded-lg text-[#00ff00] placeholder-[#00ff00]/40 focus:outline-none focus:border-[#00ff00]/60 transition-colors"
+      />
+      {value && (
+        <button
+          onClick={handleClear}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-[#00ff00]/40 hover:text-[#00ff00] transition-colors"
+          aria-label="Clear search"
+        >
+          &times;
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/TagGrid.tsx
+++ b/components/TagGrid.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import SearchInput from './SearchInput';
+
+interface TagGridProps {
+  categorizedTags: Record<string, Array<[string, number]>>;
+  totalTags: number;
+  totalPosts: number;
+}
+
+export default function TagGrid({ categorizedTags, totalTags, totalPosts }: TagGridProps) {
+  const [query, setQuery] = useState('');
+
+  // When searching, flatten all tags and filter
+  const isSearching = query.length > 0;
+
+  const allTagsFlat = Object.values(categorizedTags).flat();
+  const filteredTags = isSearching
+    ? allTagsFlat.filter(([tag]) => tag.toLowerCase().includes(query.toLowerCase()))
+    : [];
+
+  return (
+    <>
+      <div className="flex justify-center mb-8">
+        <SearchInput placeholder="Search tags..." onSearch={setQuery} />
+      </div>
+
+      {isSearching ? (
+        <div className="border border-[#00ff00]/20 rounded-lg p-6">
+          <h2 className="text-2xl font-bold mb-4 text-[#00ff00]">
+            Results ({filteredTags.length})
+          </h2>
+          {filteredTags.length === 0 ? (
+            <p className="text-[#00ff00]/70">No tags match your search.</p>
+          ) : (
+            <div className="flex flex-wrap gap-3">
+              {filteredTags.map(([tag, count]) => (
+                <Link
+                  key={tag}
+                  href={`/blog/tag/${encodeURIComponent(tag)}`}
+                  className="group px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-full text-[#00ff00]/80 hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors"
+                >
+                  <span className="font-medium">#{tag}</span>
+                  <span className="ml-2 text-xs text-[#00ff00]/60 group-hover:text-[#00ff00]/80">
+                    ({count})
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {Object.entries(categorizedTags).map(([category, tags]) => {
+            if (tags.length === 0) return null;
+            return (
+              <section key={category} className="border border-[#00ff00]/20 rounded-lg p-6">
+                <h2 className="text-2xl font-bold mb-4 text-[#00ff00]">{category}</h2>
+                <div className="flex flex-wrap gap-3">
+                  {tags.map(([tag, count]) => (
+                    <Link
+                      key={tag}
+                      href={`/blog/tag/${encodeURIComponent(tag)}`}
+                      className="group px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-full text-[#00ff00]/80 hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors"
+                    >
+                      <span className="font-medium">#{tag}</span>
+                      <span className="ml-2 text-xs text-[#00ff00]/60 group-hover:text-[#00ff00]/80">
+                        ({count})
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mt-12 text-center">
+        <div className="inline-flex items-center gap-8 px-6 py-4 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-lg">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-[#00ff00]">{totalTags}</div>
+            <div className="text-sm text-[#00ff00]/70">Total Tags</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-[#00ff00]">{totalPosts}</div>
+            <div className="text-sm text-[#00ff00]/70">Total Posts</div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -18,12 +18,6 @@ const nextConfig = {
   },
   async redirects() {
     return [
-      // Redirect old tag pages (removed in favor of /blog?tag=) — 301 for SEO
-      {
-        source: '/blog/tag/:tag',
-        destination: '/blog?tag=:tag',
-        permanent: true,
-      },
       // /blog/tag with no slug → tags hub
       {
         source: '/blog/tag',


### PR DESCRIPTION
- Add /blog/tag/[tag] dynamic route with generateStaticParams from post-index.json
- Remove 301 redirect from /blog/tag/:tag (now a real page again)
- Update all tag links to /blog/tag/{tag} (slug page, tags hub)
- Add tag pages to sitemap.xml at priority 0.5
- Add search bar to blog listing (client-side title filter)
- Add search bar to tags page (client-side tag name filter)
- New components: SearchInput, BlogPostList, TagGrid
- /blog?tag=X still works (no regression)

Closes #157