### PR TITLE
fix: API responses cached by CDN, PATCH writes lost

### DIFF
--- a/app/api/automation/transcripts/[id]/route.ts
+++ b/app/api/automation/transcripts/[id]/route.ts
@@ -57,7 +57,9 @@ export async function PATCH(
       return NextResponse.json({ error: 'Transcript not found' }, { status: 404 });
     }
 
-    return NextResponse.json({ transcript: data });
+    return NextResponse.json({ transcript: data }, {
+      headers: { 'Cache-Control': 'private, no-store' },
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/app/api/automation/transcripts/next-unprocessed/route.ts
+++ b/app/api/automation/transcripts/next-unprocessed/route.ts
@@ -24,7 +24,9 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    return NextResponse.json({ transcript: data ?? null });
+    return NextResponse.json({ transcript: data ?? null }, {
+      headers: { 'Cache-Control': 'private, no-store' },
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/next.config.js
+++ b/next.config.js
@@ -35,6 +35,7 @@ const nextConfig = {
   },
   async headers() {
     return [
+      // Security header for all routes
       {
         source: '/(.*)',
         headers: [
@@ -42,13 +43,19 @@ const nextConfig = {
             key: 'X-Frame-Options',
             value: 'SAMEORIGIN',
           },
-          // Cache static assets
+        ],
+      },
+      // API routes: never cache
+      {
+        source: '/api/(.*)',
+        headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
+            value: 'private, no-store, no-cache, must-revalidate',
           },
         ],
       },
+      // Static assets: long cache
       {
         source: '/images/(.*)',
         headers: [
@@ -68,7 +75,17 @@ const nextConfig = {
         ],
       },
       {
-        source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+        source: '/_next/static/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      // Pages: moderate cache (excludes api, static assets)
+      {
+        source: '/((?!api|_next/static|_next/image|favicon.ico|images|icons).*)',
         headers: [
           {
             key: 'Cache-Control',


### PR DESCRIPTION
## Summary

- The catch-all header rule `source: '/(.*)'` in `next.config.js` was setting `Cache-Control: public, max-age=31536000, immutable` on **all** responses including `/api/*` routes
- This caused Vercel's CDN to serve stale GET responses for `/api/automation/transcripts/next-unprocessed`, making PATCH updates to `is_processed` appear to not persist
- The pipeline looped on the same transcript indefinitely because the cached GET kept returning `is_processed: false`

### Changes
- Remove the blanket 1-year cache rule from all routes
- Add explicit `no-store` cache headers for `/api/*` routes in `next.config.js`
- Add per-response `Cache-Control: private, no-store` headers on automation API endpoints
- Keep long cache only for static assets (images, icons, `_next/static`)
- Keep 1-hour cache for pages (excluding API routes)

Fixes #160

## Test plan

- [ ] `PATCH /api/automation/transcripts/:id` with `{"is_processed": true}` persists
- [ ] `GET /api/automation/transcripts/next-unprocessed` returns a different transcript (or null) after PATCH
- [ ] Verify `curl -I` on API routes shows `Cache-Control: private, no-store`
- [ ] Verify static assets still have long cache headers
- [ ] Blog pages still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)