### PR TITLE
fix: robots.txt not blocking admin/API paths

### DIFF
--- a/__tests__/build-validation.test.js
+++ b/__tests__/build-validation.test.js
@@ -99,8 +99,8 @@ describe('Build Validation', () => {
       expect(fs.existsSync('public/images/logo.png')).toBe(true);
     });
 
-    test('should have robots.txt', () => {
-      expect(fs.existsSync('public/robots.txt')).toBe(true);
+    test('should have robots.txt route handler', () => {
+      expect(fs.existsSync('app/robots.ts')).toBe(true);
     });
   });
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/admin/', '/api/', '/forgot-password', '/reset-password'],
+      },
+    ],
+    sitemap: 'https://cyberworldbuilders.com/sitemap.xml',
+  }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,9 +1,0 @@
-User-agent: *
-Allow: /
-
-# Sitemap
-Sitemap: https://cyberworldbuilders.com/sitemap.xml
-
-# Disallow admin or private areas (if any)
-# Disallow: /admin/
-# Disallow: /private/


### PR DESCRIPTION
## Summary

- Delete static `public/robots.txt` (Disallow rules were commented out, Cloudflare was overwriting it)
- Add `app/robots.ts` route handler so Next.js generates `/robots.txt` with proper rules
- Disallow `/admin/`, `/api/`, `/forgot-password`, `/reset-password`
- Include sitemap reference

Fixes #166

## Test plan

- [ ] `curl -sL https://cyberworldbuilders.com/robots.txt` shows Disallow rules for `/admin/` and `/api/`
- [ ] Sitemap reference present in output
- [ ] Blog and other public pages still accessible to crawlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)