### PR TITLE
feat: add dynamic OG images for blog posts

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,0 +1,124 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const title = searchParams.get('title') || 'CyberWorld Builders';
+  const description = searchParams.get('description') || '';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          backgroundColor: '#000000',
+          padding: '60px',
+          fontFamily: 'monospace',
+        }}
+      >
+        {/* Decorative top border */}
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '4px',
+            background: 'linear-gradient(90deg, #00ff00 0%, #00cc00 50%, #009900 100%)',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+          }}
+        />
+
+        {/* Main content */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+          {/* Terminal prompt */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              color: '#00ff00',
+              fontSize: '20px',
+              opacity: 0.6,
+            }}
+          >
+            {'>'} cyberworldbuilders.com/blog
+          </div>
+
+          {/* Title */}
+          <div
+            style={{
+              display: 'flex',
+              fontSize: title.length > 60 ? '40px' : '48px',
+              fontWeight: 700,
+              color: '#00ff00',
+              lineHeight: 1.2,
+              maxWidth: '1000px',
+            }}
+          >
+            {title}
+          </div>
+
+          {/* Description */}
+          {description && (
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '22px',
+                color: '#00ff00',
+                opacity: 0.7,
+                lineHeight: 1.4,
+                maxWidth: '900px',
+              }}
+            >
+              {description.length > 140 ? description.slice(0, 140) + '...' : description}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            width: '100%',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              color: '#00ff00',
+              fontSize: '24px',
+              fontWeight: 700,
+            }}
+          >
+            CyberWorld Builders
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              color: '#00ff00',
+              opacity: 0.5,
+              fontSize: '18px',
+            }}
+          >
+            Jay Long — Software Engineer & Founder
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -29,7 +29,10 @@ export async function generateMetadata({ params }: BlogPostProps): Promise<Metad
   const title = metadata.title;
   const description = metadata.description || `Read about ${title} - Software engineering insights from CyberWorld Builders.`;
   const url = metadata.canonicalUrl || `https://cyberworldbuilders.com/blog/${slug}`;
-  const socialImage = metadata.socialImage?.trim() || 'https://cyberworldbuilders.com/images/social-card.png';
+  const ogParams = new URLSearchParams({ title });
+  if (description) ogParams.set('description', description);
+  const dynamicOgImage = `https://cyberworldbuilders.com/api/og?${ogParams.toString()}`;
+  const socialImage = metadata.socialImage?.trim() || dynamicOgImage;
 
   return {
     title,


### PR DESCRIPTION
## Summary

- Add `/api/og` edge route using `next/og` (satori) to generate branded 1200x630 OG images
- Green-on-black terminal theme matching the site aesthetic
- Renders post title + description dynamically via query params
- Update blog `[slug]/page.tsx` `generateMetadata` to use dynamic OG URL instead of static `social-card.png`
- Posts with explicit `socialImage` in metadata still use their custom image

### OG image template includes:
- Green gradient top border
- Terminal-style prompt (`> cyberworldbuilders.com/blog`)
- Post title (font size adapts for long titles)
- Truncated description
- "CyberWorld Builders" branding + author line

Fixes #168

## Test plan

- [ ] `curl -s -o /dev/null -w "%{http_code} %{content_type}" "https://cyberworldbuilders.com/api/og?title=Test"` returns `200 image/png`
- [ ] Blog post `<meta property="og:image">` points to `/api/og?title=...` URL
- [ ] Test with [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
- [ ] Test with [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/)
- [ ] Posts with custom `socialImage` metadata still use their image

🤖 Generated with [Claude Code](https://claude.com/claude-code)