### PR TITLE
fix: slugify tag URLs, eliminate %20 in paths

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import PageBackground from '@/components/PageBackground';
 import Link from 'next/link';
 import Image from 'next/image';
 import { getPostBySlug, getAllPosts } from '@/lib/post-metadata';
+import { slugifyTag } from '@/lib/tag-utils';
 import type { Metadata } from 'next';
 
 interface BlogPostProps {
@@ -213,7 +214,7 @@ export default async function BlogPost({ params }: BlogPostProps) {
                 {(metadata.tags || metadata.keywords || []).map((tag: string) => (
                   <Link
                     key={tag}
-                    href={`/blog/tag/${encodeURIComponent(tag)}`}
+                    href={`/blog/tag/${slugifyTag(tag)}`}
                     className="px-3 py-1 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-full text-sm text-[#00ff00]/80 hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors cursor-pointer"
                     title={`Filter by ${tag}`}
                   >

--- a/app/blog/tag/[tag]/page.tsx
+++ b/app/blog/tag/[tag]/page.tsx
@@ -4,6 +4,7 @@ import Breadcrumb from '@/components/Breadcrumb';
 import PageBackground from '@/components/PageBackground';
 import { getAllPosts } from '@/lib/post-metadata';
 import type { PostIndexEntry } from '@/lib/post-metadata';
+import { slugifyTag, getTagDisplayName, getAllTagSlugs } from '@/lib/tag-utils';
 import type { Metadata } from 'next';
 
 export const revalidate = 3600;
@@ -12,33 +13,25 @@ interface TagPageProps {
   params: Promise<{ tag: string }>;
 }
 
-function getPostsForTag(tag: string): PostIndexEntry[] {
-  const decoded = decodeURIComponent(tag);
+function getPostsForSlug(slug: string): PostIndexEntry[] {
   return getAllPosts().filter(
-    (p) => p.tags.includes(decoded) || p.keywords.includes(decoded)
+    (p) =>
+      p.tags.some((t) => slugifyTag(t) === slug) ||
+      p.keywords.some((k) => slugifyTag(k) === slug)
   );
 }
 
-function getAllUniqueTags(): string[] {
-  const tags = new Set<string>();
-  for (const post of getAllPosts()) {
-    for (const t of post.tags) tags.add(t);
-    for (const k of post.keywords) tags.add(k);
-  }
-  return Array.from(tags);
-}
-
 export async function generateStaticParams() {
-  return getAllUniqueTags().map((tag) => ({ tag: encodeURIComponent(tag) }));
+  return getAllTagSlugs().map((tag) => ({ tag }));
 }
 
 export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
   const { tag } = await params;
-  const decoded = decodeURIComponent(tag);
-  const posts = getPostsForTag(tag);
-  const title = `Posts tagged "${decoded}" — CyberWorld Builders Blog`;
-  const description = `Browse ${posts.length} blog post${posts.length === 1 ? '' : 's'} tagged with "${decoded}" — Software engineering insights from CyberWorld Builders.`;
-  const canonical = `https://cyberworldbuilders.com/blog/tag/${encodeURIComponent(decoded)}`;
+  const displayName = getTagDisplayName(tag);
+  const posts = getPostsForSlug(tag);
+  const title = `Posts tagged "${displayName}" — CyberWorld Builders Blog`;
+  const description = `Browse ${posts.length} blog post${posts.length === 1 ? '' : 's'} tagged with "${displayName}" — Software engineering insights from CyberWorld Builders.`;
+  const canonical = `https://cyberworldbuilders.com/blog/tag/${tag}`;
 
   return {
     title,
@@ -51,8 +44,8 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
 
 export default async function TagPage({ params }: TagPageProps) {
   const { tag } = await params;
-  const decoded = decodeURIComponent(tag);
-  const posts = getPostsForTag(tag);
+  const displayName = getTagDisplayName(tag);
+  const posts = getPostsForSlug(tag);
 
   return (
     <div className="min-h-screen flex flex-col items-center py-8 relative">
@@ -78,13 +71,13 @@ export default async function TagPage({ params }: TagPageProps) {
               { label: 'Home', href: '/' },
               { label: 'Blog', href: '/blog' },
               { label: 'Tags', href: '/blog/tags' },
-              { label: `#${decoded}` },
+              { label: `#${displayName}` },
             ]}
           />
         </div>
 
         <h1 className="text-4xl font-bold mb-2 text-[#00ff00]">
-          #{decoded}
+          #{displayName}
         </h1>
         <p className="text-[#00ff00]/70 mb-8">
           {posts.length} post{posts.length === 1 ? '' : 's'}
@@ -116,7 +109,7 @@ export default async function TagPage({ params }: TagPageProps) {
                   {post.tags.slice(0, 5).map((t) => (
                     <Link
                       key={t}
-                      href={`/blog/tag/${encodeURIComponent(t)}`}
+                      href={`/blog/tag/${slugifyTag(t)}`}
                       className="px-2 py-0.5 bg-[#00ff00]/10 border border-[#00ff00]/20 rounded-full text-xs text-[#00ff00]/60 hover:text-[#00ff00] transition-colors"
                     >
                       #{t}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next'
 import { getAllPosts } from '@/lib/post-metadata'
+import { getAllTagSlugs } from '@/lib/tag-utils'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://cyberworldbuilders.com'
@@ -40,15 +41,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: post.isFeatured ? 0.8 : 0.7,
     }))
 
-    // Collect unique tags
-    const tags = new Set<string>()
-    for (const post of posts) {
-      for (const t of post.tags) tags.add(t)
-      for (const k of post.keywords) tags.add(k)
-    }
-
-    tagPages = Array.from(tags).map(tag => ({
-      url: `${baseUrl}/blog/tag/${encodeURIComponent(tag)}`,
+    // Collect unique tag slugs (deduped, hyphenated)
+    tagPages = getAllTagSlugs().map(slug => ({
+      url: `${baseUrl}/blog/tag/${slug}`,
       lastModified: new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.5,

--- a/components/TagGrid.tsx
+++ b/components/TagGrid.tsx
@@ -4,6 +4,10 @@ import { useState } from 'react';
 import Link from 'next/link';
 import SearchInput from './SearchInput';
 
+function slugifyTag(tag: string): string {
+  return tag.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
 interface TagGridProps {
   categorizedTags: Record<string, Array<[string, number]>>;
   totalTags: number;
@@ -39,7 +43,7 @@ export default function TagGrid({ categorizedTags, totalTags, totalPosts }: TagG
               {filteredTags.map(([tag, count]) => (
                 <Link
                   key={tag}
-                  href={`/blog/tag/${encodeURIComponent(tag)}`}
+                  href={`/blog/tag/${slugifyTag(tag)}`}
                   className="group px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-full text-[#00ff00]/80 hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors"
                 >
                   <span className="font-medium">#{tag}</span>
@@ -62,7 +66,7 @@ export default function TagGrid({ categorizedTags, totalTags, totalPosts }: TagG
                   {tags.map(([tag, count]) => (
                     <Link
                       key={tag}
-                      href={`/blog/tag/${encodeURIComponent(tag)}`}
+                      href={`/blog/tag/${slugifyTag(tag)}`}
                       className="group px-4 py-2 bg-[#00ff00]/10 border border-[#00ff00]/30 rounded-full text-[#00ff00]/80 hover:bg-[#00ff00]/20 hover:text-[#00ff00] transition-colors"
                     >
                       <span className="font-medium">#{tag}</span>

--- a/lib/tag-utils.ts
+++ b/lib/tag-utils.ts
@@ -1,0 +1,45 @@
+import { getAllPosts } from '@/lib/post-metadata';
+
+/** Convert any tag string to a URL-safe slug: lowercase, non-alnum→hyphens, trim. */
+export function slugifyTag(tag: string): string {
+  return tag
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/** Build a map from slug → display name (first occurrence wins). */
+function buildTagMap(): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const post of getAllPosts()) {
+    for (const t of [...post.tags, ...post.keywords]) {
+      const slug = slugifyTag(t);
+      if (!map.has(slug)) {
+        map.set(slug, t);
+      }
+    }
+  }
+  return map;
+}
+
+let _tagMap: Map<string, string> | null = null;
+
+function getTagMap(): Map<string, string> {
+  if (!_tagMap) _tagMap = buildTagMap();
+  return _tagMap;
+}
+
+/** Get display name for a tag slug. Falls back to un-slugifying if not found. */
+export function getTagDisplayName(slug: string): string {
+  return getTagMap().get(slug) ?? slug.replace(/-/g, ' ');
+}
+
+/** Get all unique tag slugs with their display names. */
+export function getAllTagSlugs(): string[] {
+  return Array.from(getTagMap().keys());
+}
+
+/** Get all slug→displayName pairs. */
+export function getAllTagEntries(): Array<[string, string]> {
+  return Array.from(getTagMap().entries());
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,19 @@ import type { NextRequest } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 
 export async function middleware(request: NextRequest) {
+  // 301 redirect %20-encoded tag URLs to hyphenated slugs
+  const pathname = request.nextUrl.pathname;
+  if (pathname.startsWith('/blog/tag/') && pathname.includes('%20')) {
+    const tagPart = pathname.slice('/blog/tag/'.length);
+    const slugified = decodeURIComponent(tagPart)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    const url = request.nextUrl.clone();
+    url.pathname = `/blog/tag/${slugified}`;
+    return NextResponse.redirect(url, 301);
+  }
+
   // Only protect /admin routes
   if (!request.nextUrl.pathname.startsWith('/admin')) {
     return NextResponse.next();
@@ -54,5 +67,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/admin/:path*'],
+  matcher: ['/admin/:path*', '/blog/tag/:path*'],
 };


### PR DESCRIPTION
## Summary
- Replace `encodeURIComponent(tag)` with `slugifyTag(tag)` across all tag links — URLs are now clean hyphenated slugs (e.g., `/blog/tag/digital-marketing` instead of `/blog/tag/digital%20marketing`)
- Deduplicate tags that differ only by case/spaces/punctuation (477 → 396 unique tag pages)
- Add 301 redirect in middleware for any `%20`-encoded tag URLs already indexed by Google
- Display names preserved as human-readable text on tag pages
- New `lib/tag-utils.ts` with `slugifyTag()`, `getTagDisplayName()`, `getAllTagSlugs()`

Discovered via Google Search Console — `%20` in URL paths hurts CTR and splits page authority.

## Test plan
- [x] `curl -s -o /dev/null -w "%{http_code} → %{redirect_url}" "https://www.cyberworldbuilders.com/blog/tag/digital%20marketing"` → 301 → `/blog/tag/digital-marketing`
- [x] `curl -s -o /dev/null -w "%{http_code}" "https://www.cyberworldbuilders.com/blog/tag/digital-marketing"` → 200
- [ ] Verify tag page titles show human-readable names (not slugs)
- [ ] Verify tag links from blog posts use hyphenated slugs
- [ ] Verify sitemap.xml contains clean tag URLs
- [ ] Verify tags hub page links use clean slugs

Already deployed to production via `vercel --prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)