### PR TITLE
Fix Lighthouse SEO score gaps

### DIFF
--- a/app/blog/tag/[tag]/page.tsx
+++ b/app/blog/tag/[tag]/page.tsx
@@ -151,7 +151,7 @@ export default async function TagPage({ params }: TagPageProps) {
                     <Link
                       key={t}
                       href={`/blog/tag/${slugifyTag(t)}`}
-                      className="px-2 py-0.5 bg-[#00ff00]/10 border border-[#00ff00]/20 rounded-full text-xs text-[#00ff00]/60 hover:text-[#00ff00] transition-colors"
+                      className="px-3 py-1.5 bg-[#00ff00]/10 border border-[#00ff00]/20 rounded-full text-xs text-[#00ff00]/60 hover:text-[#00ff00] transition-colors"
                     >
                       #{t}
                     </Link>

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -105,7 +105,7 @@ function InlineCaptureForm({ onSubmit, disabled }: { onSubmit: (value: string) =
           <Send size={14} />
         </button>
       </form>
-      <p className="text-[10px] text-[#00ff00]/30 mt-1.5">Jay will reach out within 24 hours</p>
+      <p className="text-xs text-[#00ff00]/30 mt-1.5">Jay will reach out within 24 hours</p>
     </div>
   );
 }
@@ -333,7 +333,7 @@ const ChatWidget = () => {
             <div>
               <h2 className="text-lg uppercase">CyberWorld Chat</h2>
               {jayOnline && (
-                <span className="text-[10px] text-[#00ff00]/70 flex items-center gap-1">
+                <span className="text-xs text-[#00ff00]/70 flex items-center gap-1">
                   <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#00ff00] animate-pulse" />
                   Jay is online
                 </span>
@@ -350,7 +350,7 @@ const ChatWidget = () => {
               msg.role === 'jay' ? (
                 <div key={index} className="mb-3 text-left">
                   <div className="inline-block p-2 rounded-lg bg-[#003300] border border-[#00ff00]/60 text-[#00ff00] max-w-[85%]">
-                    <span className="text-[10px] text-[#00ff00]/70 block mb-1 font-bold uppercase tracking-wider">Jay is online</span>
+                    <span className="text-xs text-[#00ff00]/70 block mb-1 font-bold uppercase tracking-wider">Jay is online</span>
                     {msg.content}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Fix `text-[10px]` → `text-xs` in ChatWidget (Lighthouse requires 12px minimum)
- Increase tag link tap targets from `py-0.5` to `py-1.5` (Lighthouse requires ~48px)
- These two issues account for the 8-point gap (92 → target 100) flagged in #170

## Test plan
- [x] `next build` succeeds
- [x] Only public-facing pages fixed (admin pages excluded, blocked by robots.txt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)