### PR TITLE
Use BlogPosting schema for richer search results

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -166,13 +166,13 @@ export default async function BlogPost({ params }: BlogPostProps) {
           </div>
         </div>
 
-        {/* Article Schema */}
+        {/* BlogPosting Schema — more specific than Article, unlocks richer SERP results */}
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
               "@context": "https://schema.org",
-              "@type": "Article",
+              "@type": "BlogPosting",
               headline: title,
               description,
               image: metadata.socialImage || "https://cyberworldbuilders.com/images/logo.png",


### PR DESCRIPTION
## Summary
- Change blog post JSON-LD from `@type: "Article"` to `@type: "BlogPosting"`
- BlogPosting is more specific and can unlock richer SERP features
- All other items in #186 were false positives from the crawler (structured data, H1s, alt text, sitemap all already correct)
- Closes #186

## Test plan
- [x] `next build` succeeds
- [x] Schema validates against schema.org BlogPosting spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)