### PR TITLE
Fix schema address: Guntersville, AL (not Collinsville, IL)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -338,29 +338,19 @@ export default function RootLayout({
               "priceRange": "$$",
               "address": {
                 "@type": "PostalAddress",
-                "addressLocality": "Collinsville",
-                "addressRegion": "IL",
+                "addressLocality": "Guntersville",
+                "addressRegion": "AL",
                 "addressCountry": "US"
               },
               "geo": {
                 "@type": "GeoCoordinates",
-                "latitude": 38.6703,
-                "longitude": -89.9845
+                "latitude": 34.3582,
+                "longitude": -86.2947
               },
-              "areaServed": [
-                {
-                  "@type": "Country",
-                  "name": "United States"
-                },
-                {
-                  "@type": "City",
-                  "name": "Collinsville",
-                  "containedInPlace": {
-                    "@type": "State",
-                    "name": "Illinois"
-                  }
-                }
-              ],
+              "areaServed": {
+                "@type": "Country",
+                "name": "United States"
+              },
               "serviceType": [
                 "Custom Software Development",
                 "Marketing Automation",


### PR DESCRIPTION
## Summary
- Fixed ProfessionalService JSON-LD schema address from Collinsville, IL to Guntersville, AL
- Collinsville, IL was incorrectly copied from a client project — CyberWorld Builders is based in Guntersville, AL
- Updated geo coordinates to match (34.3582, -86.2947)
- Simplified `areaServed` to just "United States" (national service area, not local-only)

## Test plan
- [x] `next build` passes
- [ ] Verify schema in Google Rich Results Test after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)