### PR TITLE
Replace chat bubble with terminal whisper system

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -91,6 +91,8 @@ export async function POST(request: NextRequest) {
     const history: ChatMessage[] = Array.isArray(body.history) ? body.history : [];
     const sessionId: string | undefined = body.sessionId;
     const page: string | undefined = body.page;
+    const pageContext: Record<string, unknown> | undefined = body.pageContext;
+    const funnelActive: boolean = body.funnelActive ?? false;
 
     if (!message) {
       return NextResponse.json({ error: 'Message is required' }, { status: 400 });
@@ -108,15 +110,28 @@ export async function POST(request: NextRequest) {
       headers['X-Chat-Secret'] = CHAT_API_SECRET;
     }
 
+    const gusPayload: Record<string, unknown> = {
+      message,
+      history,
+      contactCaptured,
+      sessionId: sessionId || '',
+    };
+
+    // Forward full page context so GusClaw knows what the visitor is viewing
+    if (pageContext) {
+      gusPayload.pageContext = pageContext;
+    }
+    if (page) {
+      gusPayload.page = page;
+    }
+    // Signal whether Jay has timed out — GusClaw should only push
+    // for contact capture after this goes true
+    gusPayload.funnelActive = funnelActive;
+
     const gusResponse = await fetch(`${GUSCLAW_CHAT_URL}/chat`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({
-        message,
-        history,
-        contactCaptured,
-        sessionId: sessionId || '',
-      }),
+      body: JSON.stringify(gusPayload),
     });
 
     if (!gusResponse.ok) {

--- a/app/api/chat/whisper/route.ts
+++ b/app/api/chat/whisper/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { checkRateLimit } from '@/lib/rate-limit';
+
+const GUSCLAW_CHAT_URL = process.env.GUSCLAW_CHAT_URL || 'https://gusclaw-chat.cyberworldbuilders.com';
+const CHAT_API_SECRET = process.env.CHAT_API_SECRET || '';
+
+/**
+ * POST /api/chat/whisper
+ *
+ * Asks GusClaw to generate a unique, contextual opening whisper
+ * for the terminal based on what page the visitor is viewing.
+ * Returns { hook: string, followUp: string }.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      request.headers.get('cf-connecting-ip') ||
+      'anonymous';
+
+    const { ok: rateOk } = await checkRateLimit(`whisper:${ip}`);
+    if (!rateOk) {
+      return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    }
+
+    const body = await request.json();
+    const sessionId: string = body.sessionId || '';
+    const pageContext: Record<string, unknown> = body.pageContext || {};
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (CHAT_API_SECRET) {
+      headers['X-Chat-Secret'] = CHAT_API_SECRET;
+    }
+
+    const gusResponse = await fetch(`${GUSCLAW_CHAT_URL}/chat/whisper`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        sessionId,
+        pageContext,
+      }),
+    });
+
+    if (!gusResponse.ok) {
+      return NextResponse.json({ error: 'Whisper unavailable' }, { status: 502 });
+    }
+
+    const data = await gusResponse.json();
+    return NextResponse.json({
+      hook: data.hook || '',
+      followUp: data.followUp || '',
+    });
+  } catch (error: unknown) {
+    console.error('[whisper] error:', error);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/components/DeferredWidgets.tsx
+++ b/components/DeferredWidgets.tsx
@@ -2,22 +2,20 @@
 
 import { useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
+import TerminalWhisper from '@/components/TerminalWhisper';
 
 const GoogleAnalytics = dynamic(() => import('@/components/GoogleAnalytics'), { ssr: false });
 const PerformanceMonitor = dynamic(() => import('@/components/PerformanceMonitor'), { ssr: false });
-const ChatWidget = dynamic(() => import('@/components/ChatWidget'), { ssr: false });
 
 export default function DeferredWidgets() {
-  const [loadChat, setLoadChat] = useState(false);
+  const [loadTerminal, setLoadTerminal] = useState(false);
 
   useEffect(() => {
-    // Defer ChatWidget until the browser is idle or 3s has passed,
-    // whichever comes first. This keeps it off the critical path for TBT.
     if ('requestIdleCallback' in window) {
-      const id = requestIdleCallback(() => setLoadChat(true), { timeout: 3000 });
+      const id = requestIdleCallback(() => setLoadTerminal(true), { timeout: 3000 });
       return () => cancelIdleCallback(id);
     } else {
-      const timer = setTimeout(() => setLoadChat(true), 3000);
+      const timer = setTimeout(() => setLoadTerminal(true), 3000);
       return () => clearTimeout(timer);
     }
   }, []);
@@ -26,7 +24,7 @@ export default function DeferredWidgets() {
     <>
       <GoogleAnalytics />
       <PerformanceMonitor />
-      {loadChat && <ChatWidget />}
+      {loadTerminal && <TerminalWhisper />}
     </>
   );
 }

--- a/components/TerminalWhisper.tsx
+++ b/components/TerminalWhisper.tsx
@@ -1,0 +1,705 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { trackEvent, getSession } from '@/lib/tracking';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Message {
+  role: 'user' | 'bot' | 'jay';
+  content: string;
+}
+
+interface WhisperLine {
+  text: string;
+  /** Delay before this line starts typing (ms) */
+  delay?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Page context — enriches every interaction, not just blog posts
+// ---------------------------------------------------------------------------
+
+import postIndex from '@/lib/post-index.json';
+
+interface PostEntry {
+  slug: string;
+  title: string;
+  description: string;
+  category: string;
+  topics: string[];
+  tags: string[];
+}
+
+interface PageContext {
+  path: string;
+  pageType: 'blog-post' | 'blog-index' | 'service-tier' | 'service-meta' | 'case-study' | 'homepage' | 'other';
+  article?: {
+    slug: string;
+    title: string;
+    description: string;
+    category: string;
+    tags: string[];
+    related: { slug: string; title: string }[];
+  };
+  serviceTier?: string;
+}
+
+const postsById = new Map<string, PostEntry>();
+for (const p of postIndex.posts) {
+  postsById.set(p.slug, p as PostEntry);
+}
+
+function getRelatedSlugs(current: PostEntry, max = 3): string[] {
+  const scores: { slug: string; score: number }[] = [];
+  for (const p of postIndex.posts) {
+    if (p.slug === current.slug) continue;
+    const overlap = (p.topics as string[]).filter(t => current.topics.includes(t)).length;
+    if (overlap > 0) scores.push({ slug: p.slug, score: overlap });
+  }
+  scores.sort((a, b) => b.score - a.score);
+  return scores.slice(0, max).map(s => s.slug);
+}
+
+function buildPageContext(pathname: string): PageContext {
+  // Blog post
+  if (pathname.startsWith('/blog/') && pathname !== '/blog/') {
+    const slug = pathname.replace('/blog/', '').replace(/\/$/, '');
+    const post = postsById.get(slug);
+    if (post) {
+      const relatedSlugs = getRelatedSlugs(post);
+      const related = relatedSlugs
+        .map(s => postsById.get(s))
+        .filter((p): p is PostEntry => !!p)
+        .map(p => ({ slug: p.slug, title: p.title }));
+      return {
+        path: pathname,
+        pageType: 'blog-post',
+        article: {
+          slug: post.slug,
+          title: post.title,
+          description: post.description,
+          category: post.category,
+          tags: post.tags,
+          related,
+        },
+      };
+    }
+    return { path: pathname, pageType: 'blog-post' };
+  }
+
+  if (pathname === '/blog' || pathname === '/blog/') {
+    return { path: pathname, pageType: 'blog-index' };
+  }
+
+  // Service pages
+  const tierMatch = pathname.match(/^\/services\/(digital-marketing|automation|custom-saas)\/?$/);
+  if (tierMatch) {
+    return { path: pathname, pageType: 'service-tier', serviceTier: tierMatch[1] };
+  }
+  if (pathname.startsWith('/services/') && pathname !== '/services/') {
+    const tier = pathname.split('/')[2];
+    return { path: pathname, pageType: 'service-meta', serviceTier: tier };
+  }
+  if (pathname === '/services' || pathname === '/services/') {
+    return { path: pathname, pageType: 'service-tier' };
+  }
+
+  if (pathname === '/cemetery-software') {
+    return { path: pathname, pageType: 'case-study' };
+  }
+
+  if (pathname === '/' || pathname === '') {
+    return { path: pathname, pageType: 'homepage' };
+  }
+
+  return { path: pathname, pageType: 'other' };
+}
+
+// ---------------------------------------------------------------------------
+// Typewriter hook
+// ---------------------------------------------------------------------------
+
+function useTypewriter(text: string, speed = 35, startTyping = false) {
+  const [displayed, setDisplayed] = useState('');
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (!startTyping) {
+      setDisplayed('');
+      setDone(false);
+      return;
+    }
+
+    setDisplayed('');
+    setDone(false);
+    let i = 0;
+    const interval = setInterval(() => {
+      i++;
+      setDisplayed(text.slice(0, i));
+      if (i >= text.length) {
+        clearInterval(interval);
+        setDone(true);
+      }
+    }, speed);
+
+    return () => clearInterval(interval);
+  }, [text, speed, startTyping]);
+
+  return { displayed, done };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// Production: 45s linger, 35s prefetch. Set ?terminal=debug in URL to use 5s for testing.
+const _isDebug = typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('terminal') === 'debug';
+const LINGER_DELAY = _isDebug ? 5_000 : 45_000;
+const PREFETCH_DELAY = _isDebug ? 2_000 : 35_000;
+const JAY_TIMEOUT = 300_000;    // 5 minutes before funnel fallback kicks in
+const CHAT_STATE_KEY = 'cwb_terminal_state';
+
+// ---------------------------------------------------------------------------
+// Session persistence
+// ---------------------------------------------------------------------------
+
+interface TerminalState {
+  messages: Message[];
+  minimized: boolean;
+  engagedAt: number | null;  // timestamp when user first engaged
+}
+
+function saveState(state: TerminalState) {
+  try {
+    sessionStorage.setItem(CHAT_STATE_KEY, JSON.stringify(state));
+  } catch { /* ignore */ }
+}
+
+function loadState(): TerminalState | null {
+  try {
+    const stored = sessionStorage.getItem(CHAT_STATE_KEY);
+    if (stored) return JSON.parse(stored) as TerminalState;
+  } catch { /* ignore */ }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function TerminalWhisper() {
+  const restored = useRef(loadState());
+  const [phase, setPhase] = useState<'waiting' | 'typing' | 'whispered' | 'engaged' | 'minimized'>(
+    restored.current?.minimized ? 'minimized' : 'waiting'
+  );
+  const [whisperLines, setWhisperLines] = useState<WhisperLine[]>([]);
+  const [currentLineIdx, setCurrentLineIdx] = useState(0);
+  const [typingStarted, setTypingStarted] = useState<boolean[]>([]);
+  const [messages, setMessages] = useState<Message[]>(restored.current?.messages ?? []);
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [jayOnline, setJayOnline] = useState(false);
+  const [engagedAt, setEngagedAt] = useState<number | null>(restored.current?.engagedAt ?? null);
+  const [jayResponded, setJayResponded] = useState(false);
+
+  const pageContextRef = useRef<PageContext | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const impressionFired = useRef(false);
+  const whisperFetched = useRef(false);
+
+  // Build page context on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    pageContextRef.current = buildPageContext(window.location.pathname);
+  }, []);
+
+  // Persist state
+  useEffect(() => {
+    saveState({
+      messages,
+      minimized: phase === 'minimized',
+      engagedAt,
+    });
+  }, [messages, phase, engagedAt]);
+
+  // Pre-fetch whisper from GusClaw at 10s (5s before reveal)
+  useEffect(() => {
+    if (phase !== 'waiting' || whisperFetched.current) return;
+
+    const timer = setTimeout(async () => {
+      if (whisperFetched.current) return;
+      whisperFetched.current = true;
+
+      try {
+        const ctx = pageContextRef.current ?? buildPageContext(window.location.pathname);
+        const session = getSession();
+        const res = await fetch('/api/chat/whisper', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: session.session_id,
+            pageContext: ctx,
+          }),
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          if (data.hook && data.followUp) {
+            setWhisperLines([
+              { text: `> ${data.hook}`, delay: 0 },
+              { text: `> ${data.followUp}`, delay: 4000 },
+            ]);
+            setTypingStarted([false, false]);
+            return;
+          }
+        }
+      } catch { /* fall through to fallback */ }
+
+      // Minimal fallback — still not canned, just bare-bones
+      setWhisperLines([
+        { text: '> ...', delay: 0 },
+        { text: '> still reading?', delay: 3000 },
+      ]);
+      setTypingStarted([false, false]);
+    }, PREFETCH_DELAY);
+
+    return () => clearTimeout(timer);
+  }, [phase]);
+
+  // Linger timer — reveal at 15s
+  useEffect(() => {
+    if (phase !== 'waiting') return;
+
+    // Restore previous engaged session
+    if (restored.current?.messages && restored.current.messages.length > 0 && !restored.current.minimized) {
+      setPhase('engaged');
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setPhase('typing');
+      if (!impressionFired.current) {
+        impressionFired.current = true;
+        trackEvent('terminal_whisper_impression', { page: window.location.pathname });
+      }
+    }, LINGER_DELAY);
+
+    return () => clearTimeout(timer);
+  }, [phase]);
+
+  // Drive the typewriter sequence line by line
+  useEffect(() => {
+    if (phase !== 'typing' || whisperLines.length === 0) return;
+
+    if (currentLineIdx === 0 && !typingStarted[0]) {
+      setTypingStarted(prev => {
+        const next = [...prev];
+        next[0] = true;
+        return next;
+      });
+    }
+  }, [phase, whisperLines, currentLineIdx, typingStarted]);
+
+  const handleLineDone = useCallback((lineIdx: number) => {
+    if (lineIdx < whisperLines.length - 1) {
+      const nextDelay = whisperLines[lineIdx + 1]?.delay ?? 800;
+      setTimeout(() => {
+        setCurrentLineIdx(lineIdx + 1);
+        setTypingStarted(prev => {
+          const next = [...prev];
+          next[lineIdx + 1] = true;
+          return next;
+        });
+      }, nextDelay);
+    } else {
+      setPhase('whispered');
+    }
+  }, [whisperLines]);
+
+  // Poll for Jay's messages when engaged
+  useEffect(() => {
+    if (phase !== 'engaged' || messages.length === 0) {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      return;
+    }
+
+    const session = getSession();
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/chat?sessionId=${encodeURIComponent(session.session_id)}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.jayOnline !== undefined) setJayOnline(data.jayOnline);
+        if (data.jayMessages?.length > 0) {
+          const newMsgs: Message[] = data.jayMessages
+            .filter((m: string) => m !== '__CAPTURE__')
+            .map((m: string) => ({ role: 'jay' as const, content: m }));
+          if (newMsgs.length > 0) {
+            setMessages(prev => [...prev, ...newMsgs]);
+            setJayResponded(true);
+          }
+        }
+      } catch { /* silent */ }
+    };
+
+    pollRef.current = setInterval(poll, 4000);
+    return () => {
+      if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    };
+  }, [phase, messages.length]);
+
+  // Auto-scroll messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // Focus input when entering engaged mode
+  useEffect(() => {
+    if (phase === 'engaged') {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [phase]);
+
+  // Determine if funnel mode should activate (Jay hasn't responded in 5 min)
+  const funnelActive = engagedAt !== null && !jayResponded && (Date.now() - engagedAt > JAY_TIMEOUT);
+
+  // Send message
+  const sendMessage = async (text: string) => {
+    if (!text.trim() || isLoading) return;
+
+    const userMsg: Message = { role: 'user', content: text };
+    const updated = [...messages, userMsg];
+    setMessages(updated);
+    setInput('');
+    setIsLoading(true);
+
+    const userMsgCount = updated.filter(m => m.role === 'user').length;
+    trackEvent('terminal_message_sent', { message_count: userMsgCount });
+
+    try {
+      const session = getSession();
+      const history = messages.map(m => ({
+        role: m.role === 'jay' ? 'bot' as const : m.role,
+        content: m.content,
+      }));
+
+      const ctx = pageContextRef.current ?? buildPageContext(window.location.pathname);
+
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: text,
+          history,
+          sessionId: session.session_id,
+          page: window.location.pathname,
+          pageContext: ctx,
+          funnelActive,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (data.error) {
+        setMessages(prev => [...prev, { role: 'bot', content: '> connection lost. try again.' }]);
+      } else {
+        const newMsgs: Message[] = [];
+
+        if (data.jayMessages?.length > 0) {
+          for (const jm of data.jayMessages) {
+            if (jm !== '__CAPTURE__') newMsgs.push({ role: 'jay', content: jm });
+          }
+          if (data.jayMessages.length > 0) {
+            setJayOnline(true);
+            setJayResponded(true);
+          }
+        }
+
+        newMsgs.push({ role: 'bot', content: data.response });
+        setMessages(prev => [...prev, ...newMsgs]);
+
+        // Only honor funnel signals (email capture, quick replies) after Jay timeout
+        // Before that, GusClaw should be in pure conversation mode
+      }
+    } catch {
+      setMessages(prev => [...prev, { role: 'bot', content: '> connection lost. try again.' }]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    sendMessage(input);
+  };
+
+  const handleWhisperClick = () => {
+    if (phase === 'whispered' || phase === 'typing') {
+      setPhase('engaged');
+      setEngagedAt(Date.now());
+      trackEvent('terminal_whisper_engaged', { page: window.location.pathname });
+    }
+  };
+
+  const handleMinimize = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPhase('minimized');
+    trackEvent('terminal_whisper_minimized', {});
+  };
+
+  const handleExpand = () => {
+    setPhase('engaged');
+    trackEvent('terminal_whisper_expanded', {});
+  };
+
+  // Parse message content — strip blog links from text, render them as cards below
+  const renderContent = (text: string) => {
+    const blogLinkRegex = /\/blog\/[a-zA-Z0-9-]+/g;
+    const externalLinkRegex = /(https?:\/\/[^\s]+)/g;
+
+    // Collect blog slugs
+    const blogSlugs: string[] = [];
+    let match;
+    while ((match = blogLinkRegex.exec(text)) !== null) {
+      const slug = match[0].replace('/blog/', '');
+      if (!blogSlugs.includes(slug)) blogSlugs.push(slug);
+    }
+
+    // Strip blog links from the text body
+    const cleanedText = text
+      .replace(/\/blog\/[a-zA-Z0-9-]+/g, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+
+    // Parse remaining text for external URLs
+    const textParts = cleanedText.split(externalLinkRegex);
+    const inlineContent = textParts.map((part, idx) => {
+      if (/^https?:\/\//.test(part)) {
+        return (
+          <a key={idx} href={part} target="_blank" rel="noopener noreferrer" className="text-[#00ccff] underline underline-offset-2 decoration-[#00ccff]/30 hover:decoration-[#00ccff]">
+            {part}
+          </a>
+        );
+      }
+      return <span key={idx}>{part}</span>;
+    });
+
+    // Build blog cards
+    const blogCards = blogSlugs.map(slug => {
+      const post = postsById.get(slug);
+      const fullEntry = postIndex.posts.find(p => p.slug === slug);
+      const img = fullEntry?.headerImage;
+      return (
+        <a
+          key={slug}
+          href={`/blog/${slug}`}
+          className="flex gap-2 mt-1.5 px-2 py-1.5 rounded border border-[#00ff00]/15 bg-[#00ff00]/5 hover:bg-[#00ff00]/10 transition-colors group/link"
+        >
+          {img && (
+            <img
+              src={img}
+              alt=""
+              className="w-10 h-10 rounded object-cover flex-shrink-0 opacity-70 group-hover/link:opacity-100 transition-opacity"
+            />
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="text-[#00ff00]/80 group-hover/link:text-[#00ff00] transition-colors text-xs font-medium truncate">
+              {post?.title ?? slug}
+            </div>
+            {post?.description && (
+              <div className="text-[#00ff00]/40 text-[10px] leading-tight line-clamp-2 mt-0.5">
+                {post.description}
+              </div>
+            )}
+          </div>
+        </a>
+      );
+    });
+
+    return (
+      <>
+        <span>{inlineContent}</span>
+        {blogCards.length > 0 && <div className="flex flex-col">{blogCards}</div>}
+      </>
+    );
+  };
+
+  if (phase === 'waiting') return null;
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 z-50 font-mono text-xs select-none"
+      style={{ maxWidth: 'min(420px, calc(100vw - 32px))' }}
+    >
+      {/* Whisper phase — tiny terminal text */}
+      {(phase === 'typing' || phase === 'whispered') && (
+        <div
+          onClick={handleWhisperClick}
+          className="group cursor-pointer p-3 pb-4 pl-4"
+          role="button"
+          tabIndex={0}
+          aria-label="Open terminal"
+          onKeyDown={(e) => { if (e.key === 'Enter') handleWhisperClick(); }}
+        >
+          <button
+            onClick={handleMinimize}
+            className="absolute top-1 right-1 w-4 h-4 flex items-center justify-center text-[#00ff00]/0 group-hover:text-[#00ff00]/30 hover:!text-[#00ff00]/60 transition-colors text-[10px]"
+            aria-label="Dismiss"
+          >
+            x
+          </button>
+
+          <div className="absolute inset-0 bg-[#0a0a0a]/80 backdrop-blur-sm rounded-tr-md" />
+
+          <div className="relative space-y-0.5">
+            {whisperLines.map((line, i) => (
+              <WhisperLineRenderer
+                key={i}
+                text={line.text}
+                startTyping={typingStarted[i] ?? false}
+                isLast={i === whisperLines.length - 1 || i === currentLineIdx}
+                onDone={() => handleLineDone(i)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Engaged phase — conversational terminal */}
+      {phase === 'engaged' && (
+        <div className="m-3 rounded-md overflow-hidden border border-[#00ff00]/15 shadow-[0_0_20px_rgba(0,255,0,0.05)]">
+          <div className="flex items-center justify-between px-3 py-1.5 bg-[#0a0a0a]/95 border-b border-[#00ff00]/10">
+            <div className="flex items-center gap-2">
+              <span className="text-[#00ff00]/40 text-[10px] tracking-widest uppercase">terminal</span>
+              {jayOnline && (
+                <span className="flex items-center gap-1 text-[10px] text-[#00ff00]/50">
+                  <span className="w-1 h-1 rounded-full bg-[#00ff00] animate-pulse" />
+                  live
+                </span>
+              )}
+            </div>
+            <button
+              onClick={handleMinimize}
+              className="text-[#00ff00]/30 hover:text-[#00ff00]/60 transition-colors text-[10px] leading-none"
+              aria-label="Close terminal"
+            >
+              x
+            </button>
+          </div>
+
+          <div
+            className="bg-[#0a0a0a]/95 backdrop-blur-sm px-3 py-2 overflow-y-auto"
+            style={{ maxHeight: '200px' }}
+          >
+            {messages.length === 0 && whisperLines.map((line, i) => (
+              <div key={`w-${i}`} className="text-[#00ff00]/50 leading-relaxed">
+                {line.text}
+              </div>
+            ))}
+
+            {messages.map((msg, i) => (
+              <div key={i} className="leading-relaxed">
+                {msg.role === 'user' ? (
+                  <div className="text-[#00ff00]">
+                    <span className="text-[#00ff00]/40">{'> '}</span>
+                    {msg.content}
+                  </div>
+                ) : msg.role === 'jay' ? (
+                  <div className="text-[#00ccff]">
+                    <span className="text-[#00ccff]/40">jay: </span>
+                    {renderContent(msg.content)}
+                  </div>
+                ) : (
+                  <div className="text-[#00ff00]/70">
+                    {renderContent(msg.content)}
+                  </div>
+                )}
+              </div>
+            ))}
+
+            {isLoading && (
+              <div className="text-[#00ff00]/30 animate-pulse">...</div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex items-center bg-[#0a0a0a]/95 border-t border-[#00ff00]/10 px-3 py-2">
+            <span className="text-[#00ff00]/40 mr-1.5 flex-shrink-0">{'>'}</span>
+            <input
+              ref={inputRef}
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              disabled={isLoading}
+              className="flex-1 bg-transparent text-[#00ff00] text-xs outline-none placeholder-[#00ff00]/20 caret-[#00ff00]"
+              placeholder=""
+              aria-label="Terminal input"
+              autoComplete="off"
+            />
+            <span className={`w-1.5 h-3 bg-[#00ff00] ml-0.5 flex-shrink-0 ${!input ? 'animate-pulse' : 'opacity-0'}`} />
+          </form>
+        </div>
+      )}
+
+      {/* Minimized state — tiny expand arrow */}
+      {phase === 'minimized' && (
+        <button
+          onClick={handleExpand}
+          className="m-3 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-[#0a0a0a]/90 border border-[#00ff00]/15 text-[#00ff00]/30 hover:text-[#00ff00]/60 hover:border-[#00ff00]/30 transition-colors font-mono text-xs"
+          aria-label="Expand terminal"
+        >
+          <span>{'>'}</span>
+          <span className="w-1.5 h-3 bg-current animate-pulse" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Whisper line with typewriter
+// ---------------------------------------------------------------------------
+
+function WhisperLineRenderer({
+  text,
+  startTyping,
+  isLast,
+  onDone,
+}: {
+  text: string;
+  startTyping: boolean;
+  isLast: boolean;
+  onDone: () => void;
+}) {
+  const { displayed, done } = useTypewriter(text, 30, startTyping);
+  const firedDone = useRef(false);
+
+  useEffect(() => {
+    if (done && !firedDone.current) {
+      firedDone.current = true;
+      onDone();
+    }
+  }, [done, onDone]);
+
+  if (!startTyping) return null;
+
+  return (
+    <div className="text-[#00ff00]/60 leading-relaxed whitespace-nowrap">
+      {displayed}
+      {isLast && !done && (
+        <span className="inline-block w-1.5 h-3 bg-[#00ff00]/60 align-middle ml-px animate-pulse" />
+      )}
+      {isLast && done && (
+        <span className="inline-block w-1.5 h-3 bg-[#00ff00]/40 align-middle ml-px animate-pulse" />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces floating chat bubble with a terminal-style "whisper" that activates after 45s of page linger
- Live page-aware opening lines generated by GusClaw (never canned/repetitive)
- Phase state machine: waiting → typing → whispered → engaged → minimized
- Funnel behavior deferred until Jay's 5-minute response window expires
- Blog post links rendered as rich cards with thumbnail and description
- `?terminal=debug` param for fast testing (5s activation)

## Changes
- **New**: `components/TerminalWhisper.tsx` — core terminal whisper component
- **New**: `app/api/chat/whisper/route.ts` — proxy to GusClaw whisper endpoint
- **Modified**: `app/api/chat/route.ts` — forwards pageContext and funnelActive
- **Modified**: `components/DeferredWidgets.tsx` — swaps ChatWidget for TerminalWhisper

## Depends on
- Cyberworld-builders/gus-claw terminal-whisper branch (new /chat/whisper endpoint)

## Test plan
- [ ] Terminal appears after 45s linger (or 5s with ?terminal=debug)
- [ ] Opening line references current page content
- [ ] Blog links render as rich cards below message text
- [ ] Minimize button shows blinking cursor, click to re-expand
- [ ] Funnel behavior only activates after 5min Jay timeout
- [ ] Session persists across soft navigations

🤖 Generated with [Claude Code](https://claude.com/claude-code)