### PR TITLE
fix: allow automation API key on content endpoint

### DIFF
--- a/app/api/admin/content/route.ts
+++ b/app/api/admin/content/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient as createSSRClient } from '@supabase/ssr';
 import { createServerClient } from '@/lib/supabase';
+import { validateAutomationApiKey } from '@/lib/automation-auth';
 import { cookies } from 'next/headers';
 import postIndex from '@/lib/post-index.json';
 
@@ -46,9 +47,14 @@ interface PostMeta {
  * Query params: slug, platform, status, days (default 30), sort (default: published)
  */
 export async function GET(request: NextRequest) {
-  const user = await verifyAuth();
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  // Allow automation API key (for GusClaw) or browser cookie auth (for admin UI)
+  const apiKeyError = validateAutomationApiKey(request);
+  if (apiKeyError) {
+    // API key missing or invalid — fall through to cookie auth
+    const user = await verifyAuth();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
   }
 
   const supabase = createServerClient();


### PR DESCRIPTION
## Summary
- `/api/admin/content` only accepted Supabase cookie auth, blocking GusClaw from calling it with X-API-Key
- Now checks automation API key first (same pattern as `/api/automation/social` and `/api/automation/traffic`)
- Falls through to cookie auth for browser-based admin UI users

## Test plan
- [ ] `curl -H "X-API-Key: $KEY" https://cyberworldbuilders.com/api/admin/content` returns 200
- [ ] Admin dashboard still works in browser (cookie auth path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)